### PR TITLE
SLING-10150 - sling:hideChildren incorrectly hiding parent of parent, when asterisk is used in combination with whitelisting

### DIFF
--- a/src/main/java/org/apache/sling/resourcemerger/impl/MergingResourceProvider.java
+++ b/src/main/java/org/apache/sling/resourcemerger/impl/MergingResourceProvider.java
@@ -19,9 +19,11 @@
 package org.apache.sling.resourcemerger.impl;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import com.sun.tools.javac.util.ArrayUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceUtil;
@@ -110,17 +112,14 @@ public class MergingResourceProvider extends ResourceProvider<Void> {
                     final String[] ancestorChildrenToHideArray = ancestorProps.get(MergedResourceConstants.PN_HIDE_CHILDREN, String[].class);
                     if (ancestorChildrenToHideArray != null) {
                         for (final String value : ancestorChildrenToHideArray) {
-                            final boolean onlyUnderlying;
-                            if (value.equals("*")) {
-                                onlyUnderlying = true;
-                            } else {
-                                onlyUnderlying = false;
-                            }
+                            final boolean onlyUnderlying = value.equals("*");
                             final ExcludeEntry entry = new ExcludeEntry(value, onlyUnderlying);
                             // check if this entry is applicable at all (always assuming the worst case, i.e. non local resource)
                             final Boolean hides = hides(entry, previousAncestorName, false);
-                            if (hides != null && hides.booleanValue() == true) {
-                                this.entries.add(new ExcludeEntry("*", entry.onlyUnderlying));
+                            if (hides != null) {
+                                if (Boolean.TRUE.equals(hides)) {
+                                    this.entries.add(new ExcludeEntry("*", entry.onlyUnderlying));
+                                }
                                 break;
                             }
                         }

--- a/src/main/java/org/apache/sling/resourcemerger/impl/MergingResourceProvider.java
+++ b/src/main/java/org/apache/sling/resourcemerger/impl/MergingResourceProvider.java
@@ -19,11 +19,9 @@
 package org.apache.sling.resourcemerger.impl;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-import com.sun.tools.javac.util.ArrayUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceUtil;

--- a/src/test/java/org/apache/sling/resourcemerger/impl/CommonMergedResourceProviderTest.java
+++ b/src/test/java/org/apache/sling/resourcemerger/impl/CommonMergedResourceProviderTest.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.commons.collections4.iterators.IteratorIterable;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ModifiableValueMap;
@@ -437,5 +438,57 @@ public class CommonMergedResourceProviderTest {
         IteratorIterable<Resource> iterable = new IteratorIterable<Resource>(provider.listChildren(ctx, mergedResource), true);
 
         Assert.assertThat(iterable, Matchers.contains(ResourceMatchers.name("child1"),ResourceMatchers.name("child3"),ResourceMatchers.name("child2")));
+    }
+
+    @Test
+    public void testNodesDefinedInBaseStructureShouldBeReflectedInOverlayedStructureWhenNotExcludedInCombinationWithWildcard() throws PersistenceException {
+        final String title = "title";
+        final String field = "field";
+        final String description = "description";
+
+        MockHelper.create(this.resolver)
+            // Set up the base structure, including a tab that is not desired in the overlaid situation
+            .resource("/apps/base/test")
+            .resource("/apps/base/test/tabs")
+            .resource("/apps/base/test/tabs/undesired-tab")
+            .p(title, "Undesired Tab")
+            .resource("/apps/base/test/tabs/desired-tab")
+            .p(title, "Desired Tab")
+            // Set up a field inside the items node in the desired tab, that should be reflected in the overlaid situation
+            .resource("/apps/base/test/tabs/desired-tab/items")
+            .resource("/apps/base/test/tabs/desired-tab/items/" + field)
+            // Define a property on the field inside the base tab, that should be reflected int he overlaid situation
+            .p(field, field)
+            // Set up the overlaid structure, defining the tabs again
+            .resource("/apps/overlay/test")
+            .resource("/apps/overlay/test/tabs")
+            // Explicitly define that *all* children need to be hidden from the base structure, except for the desired tab
+            .p(MergedResourceConstants.PN_HIDE_CHILDREN, new String[]{"!desired-tab", "*"})
+            .resource("/apps/overlay/test/tabs/desired-tab")
+            .resource("/apps/overlay/test/tabs/desired-tab/items")
+            .resource("/apps/overlay/test/tabs/desired-tab/items/" + field)
+            // Define an additional property on a node inside the desired tab, so that it should end up getting 2 properties
+            .p(description, description)
+            .commit();
+
+        // Ensure that the undesired tab is not found
+        final Resource tabsResource = this.provider.getResource(ctx, "/merged/test/tabs", ResourceContext.EMPTY_CONTEXT, null);
+        Assert.assertNotNull(tabsResource);
+        final IteratorIterable<Resource> tabs = new IteratorIterable<Resource>(this.provider.listChildren(ctx, tabsResource), true);
+        Assert.assertThat(tabs, Matchers.contains(
+            ResourceMatchers.nameAndProps("desired-tab", title, "Desired Tab")
+        ));
+
+        // Ensure that the desired tab also has the newly added description, as well as its original name
+        final Resource desiredTabItemsResource = this.provider.getResource(ctx, "/merged/test/tabs/desired-tab/items", ResourceContext.EMPTY_CONTEXT, null);
+        Assert.assertNotNull(desiredTabItemsResource);
+        final IteratorIterable<Resource> desiredTabItems = new IteratorIterable<Resource>(provider.listChildren(ctx, desiredTabItemsResource), true);
+        Assert.assertThat(desiredTabItems, Matchers.contains(
+            ResourceMatchers.nameAndProps(field, ImmutableMap.<String, Object>builder()
+                .put(field, field)
+                .put(description, description)
+                .build())
+            )
+        );
     }
 }

--- a/src/test/java/org/apache/sling/resourcemerger/impl/CommonMergedResourceProviderTest.java
+++ b/src/test/java/org/apache/sling/resourcemerger/impl/CommonMergedResourceProviderTest.java
@@ -441,7 +441,7 @@ public class CommonMergedResourceProviderTest {
     }
 
     @Test
-    public void testNodesDefinedInBaseStructureShouldBeReflectedInOverlayedStructureWhenNotExcludedInCombinationWithWildcard() throws PersistenceException {
+    public void testNodesDefinedInBaseStructureShouldBeReflectedInOverlaidStructureWhenNotExcludedInCombinationWithWildcard() throws PersistenceException {
         final String title = "title";
         final String field = "field";
         final String description = "description";

--- a/src/test/java/org/apache/sling/resourcemerger/impl/MergedResourceProviderTestForSearchPathBasedPicker.java
+++ b/src/test/java/org/apache/sling/resourcemerger/impl/MergedResourceProviderTestForSearchPathBasedPicker.java
@@ -159,11 +159,11 @@ public class MergedResourceProviderTestForSearchPathBasedPicker {
     }
 
     @Test public void testResourceType() {
-        // a/2 defines the property and it's overlayed
+        // a/2 defines the property and it's overlaid
         final Resource rsrcA2 = this.provider.getResource(ctx, "/merged/a/2", ResourceContext.EMPTY_CONTEXT, null);
         assertEquals("apps", rsrcA2.getResourceType());
 
-        // a/12 doesn't define the property and it's overlayed
+        // a/12 doesn't define the property and it's overlaid
         final Resource rsrcA1 = this.provider.getResource(ctx, "/merged/a/1", ResourceContext.EMPTY_CONTEXT, null);
         assertEquals("a/1", rsrcA1.getResourceType());
 


### PR DESCRIPTION
Failing test case that shows the issue with sling:hideChildren and the incorrect handling of the whitelisting in combination with asterisk