### PR TITLE
Fixes for SLING-11774, SLING-11775

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>41</version>
+        <version>49</version>
         <relativePath />
     </parent>
 
@@ -51,22 +51,27 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.framework</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.annotation.versioning</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.component.annotations</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.metatype.annotations</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
@@ -85,10 +90,16 @@
             <artifactId>annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <!-- Testing -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/src/main/java/org/apache/sling/resourcemerger/impl/MergedResourcePickerWhiteboard.java
+++ b/src/main/java/org/apache/sling/resourcemerger/impl/MergedResourcePickerWhiteboard.java
@@ -18,7 +18,9 @@
  */
 package org.apache.sling.resourcemerger.impl;
 
+import java.util.Arrays;
 import java.util.Dictionary;
+import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +34,7 @@ import org.apache.sling.resourcemerger.spi.MergedResourcePicker2;
 import org.apache.sling.spi.resource.provider.ResourceProvider;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -64,7 +67,11 @@ public class MergedResourcePickerWhiteboard {
     }
 
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE)
-    public void bindMergedResourcePicker(MergedResourcePicker resourcePicker, Map<String, Object> properties) {
+    public void bindMergedResourcePicker(MergedResourcePicker resourcePicker,
+                                         ServiceReference<MergedResourcePicker> reference) {
+        final Map<String, Object> properties = new HashMap<String, Object>();
+        Arrays.stream(reference.getPropertyKeys()).forEach(property -> properties.put(property,
+                reference.getProperty(property)));
         registerMergingResourceProvider((resolver, relativePath, relatedResource) -> resourcePicker.pickResources(resolver, relativePath), properties);
     }
 
@@ -73,7 +80,11 @@ public class MergedResourcePickerWhiteboard {
     }
 
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE)
-    public void bindMergedResourcePicker2(MergedResourcePicker2 resourcePicker, Map<String, Object> properties) {
+    public void bindMergedResourcePicker2(MergedResourcePicker2 resourcePicker,
+                                          final ServiceReference<MergedResourcePicker2> reference) {
+        final Map<String, Object> properties = new HashMap<String, Object>();
+        Arrays.stream(reference.getPropertyKeys()).forEach(property -> properties.put(property,
+                reference.getProperty(property)));
         registerMergingResourceProvider(resourcePicker, properties);
     }
 


### PR DESCRIPTION
While #8 will fix the activation of the ResourceTypeHierarchyBasedResourcePicker, without merging the component default configuration properties with the applied runtime configuration the component will still not work correctly. This PR should address that aspect.